### PR TITLE
fix frag shader

### DIFF
--- a/eweygewey.go
+++ b/eweygewey.go
@@ -78,7 +78,7 @@ var (
   {
     vs_uv = VERTEX_UV;
     vs_color = VERTEX_COLOR;
-	vs_tex_index = VERTEX_TEXTURE_INDEX;
+    vs_tex_index = VERTEX_TEXTURE_INDEX;
     gl_Position = VIEW * vec4(VERTEX_POSITION, 0.0, 1.0);
   }`
 
@@ -92,8 +92,15 @@ var (
   out vec4 frag_color;
   void main()
   {
-  	int i = int(vs_tex_index);
-	frag_color = vs_color * texture(TEX[i], vs_uv).rgba;
+    int i = int(vs_tex_index);
+    switch(int(vs_tex_index))
+    {
+      case 0: frag_color = vs_color * texture(TEX[0], vs_uv).rgba;
+      case 1: frag_color = vs_color * texture(TEX[1], vs_uv).rgba;
+      case 2: frag_color = vs_color * texture(TEX[2], vs_uv).rgba;
+      case 3: frag_color = vs_color * texture(TEX[3], vs_uv).rgba;
+    }
+    
   }`
 
 	// DefaultStyle is the default style to use for drawing widgets


### PR DESCRIPTION
Hello, again this error: `sampler arrays indexed with non-constant expressions are forbidden in GLSL 1.30 and later`, now in hardcoded fargment shader.

```
panic: Failed to initialize the user interface! Failed to compile the fragment shader:
0:10(34): error: sampler arrays indexed with non-constant expressions are forbidden in GLSL 1.30 and later


goroutine 1 [running, locked to thread]:
panic(0x62cfa0, 0xc82000a640)
    /usr/lib/go/src/runtime/panic.go:481 +0x3e6
main.main()
    [...]/go/src/github.com/tbogdala/eweygewey/examples/basicGLFW/main.go:100 +0x3d5
exit status 2
```
